### PR TITLE
feat: add Claude Code Plugin blog series (4 parts)

### DIFF
--- a/blog/2026-02-08-claude-code-plugin-part1.md
+++ b/blog/2026-02-08-claude-code-plugin-part1.md
@@ -1,0 +1,255 @@
+---
+slug: claude-code-plugin-part1
+title: "[Claude Code Plugin 만들기 #1] Plugin 입문 — AI 비서에게 업무 매뉴얼 만들어주기"
+authors: namyoungkim
+tags: [claude, claude-code, plugin, ai, dev-tools, tutorial]
+---
+
+> 이 글은 Claude Code Plugin 만들기 시리즈의 첫 번째 편입니다. Plugin이 무엇인지, 왜 필요한지, 그리고 어떤 구성 요소로 이루어져 있는지 알아봅니다.
+
+---
+
+## TL;DR
+
+- Plugin은 Claude Code에 커스텀 기능을 추가하는 확장 시스템
+- Skills(배경 지식), Commands/Skills(슬래시 명령어), Hooks(자동 규칙), Agents(전문가 팀) 4가지로 구성
+- `plugin.json` 매니페스트 하나로 패키징하여 팀과 공유 가능
+- 프로젝트별 `.claude/` 설정과 달리, Plugin은 여러 프로젝트에서 재사용 가능
+
+<!-- truncate -->
+
+---
+
+## 들어가며: 반복 설명이 이렇게 싫다고?
+
+Claude Code를 쓰다 보면 정말 좋은 AI 비서를 얻은 것 같은 기분이 듭니다. 코드 리뷰도 해주고, 버그도 찾아주고, 심지어 리팩토링까지 도와줍니다.
+
+그런데 한 가지 문제가 있습니다. **매번 같은 설명을 반복해야 한다는 것입니다.**
+
+"우리 프로젝트는 Python으로, 들여쓰기는 4칸으로, 변수명은 snake_case로..."
+
+이런 말을 매번 반복하다 보면 지칩니다. 마치 새로 온 팀원에게 매일 같은 컨벤션을 설명하는 것처럼요.
+
+**그렇다면 이렇게 하면 어떨까요?** 처음 한 번만 매뉴얼을 작성해놓고, 그 다음부터는 매뉴얼을 참고하게 하는 겁니다. Claude Code Plugin은 바로 이 역할을 합니다.
+
+---
+
+## Plugin이란? AI에게 주는 업무 매뉴얼
+
+새로 온 팀원이 첫 날부터 일을 잘할 리가 없습니다.
+
+- "코드 스타일은 뭐야?"
+- "테스트는 어떻게 돌려?"
+- "커밋 메시지 규칙이 있어?"
+- "위험한 작업은 뭐야?"
+
+이 모든 걸 매번 설명하는 건 비효율적입니다. 하지만 매뉴얼이 있다면?
+
+**Claude도 똑같습니다.** 우리가 미리 알려줄 게 있으면, Claude는 훨씬 똑똑하게 일할 수 있습니다. **Plugin은 이 매뉴얼을 체계적으로 만들어서 패키징한 것**입니다.
+
+### Plugin vs 프로젝트 설정
+
+"`.claude/` 디렉토리에 직접 설정하면 되는 거 아니야?" 맞는 말입니다. 하지만 차이가 있습니다.
+
+| 구분 | 프로젝트 설정 (`.claude/`) | Plugin |
+|------|---------------------------|--------|
+| 범위 | 해당 프로젝트만 | 여러 프로젝트에서 재사용 |
+| 공유 | 프로젝트 저장소에 포함 | 별도 저장소로 배포 |
+| 네이밍 | `/review` | `/plugin-name:review` |
+| 적합한 경우 | 프로젝트 고유 설정 | 팀 표준, 커뮤니티 공유 |
+
+하나의 프로젝트에서만 쓸 거라면 `.claude/`로 충분합니다. 하지만 여러 프로젝트에 같은 규칙을 적용하고 싶다면? Plugin으로 만들어야 합니다.
+
+---
+
+## 4가지 핵심 구성 요소
+
+Plugin을 구성하는 네 가지 요소가 있습니다. 각각이 무엇을 하는지 알아봅시다.
+
+### Skills = 배경 지식
+
+**Skills는 Claude에게 미리 알려주는 배경 지식입니다.** SKILL.md 파일에 규칙을 작성하면, Claude가 관련 상황에서 자동으로 참고합니다.
+
+예를 들어 Python 프로젝트를 다룰 때:
+- "패키지 매니저는 uv를 사용해"
+- "린터는 ruff를 써"
+- "테스트는 pytest로 돌려"
+
+이런 규칙을 SKILL.md에 적어두면, Claude는 Python 파일을 볼 때 자동으로 이 규칙들을 따릅니다.
+
+:::info Skill의 두 가지 모드
+- **자동 적용** (`user-invocable: false`): Claude가 알아서 참고하는 배경 지식
+- **수동 호출** (기본값): 사용자가 `/skill-name`으로 직접 호출하는 명령어
+:::
+
+### Commands (= 호출 가능한 Skills)
+
+공식 문서에서는 Commands와 Skills가 통합되었습니다. `.claude/commands/review.md`든 `.claude/skills/review/SKILL.md`든, 둘 다 `/review`로 호출할 수 있습니다.
+
+**Commands는 사용자가 직접 호출하는 Skills입니다.** `/code-review`라고 입력하면 코드 리뷰 모드로 들어가고, `/reflect`라고 하면 세션 회고를 시작합니다.
+
+```
+/code-review     → 현재 변경사항 코드 리뷰
+/reflect         → 세션 회고 및 교훈 기록
+/init-project    → 새 프로젝트 초기화
+```
+
+### Hooks = 자동 규칙
+
+**Hooks는 특정 이벤트가 발생하면 자동으로 실행되는 규칙입니다.** `hooks.json` 파일에 한 번만 정의해두면, 조건이 맞을 때 자동으로 동작합니다.
+
+예를 들어:
+- 파일을 저장할 때마다 → 자동으로 코드 포맷팅
+- 위험한 명령어를 실행하려 할 때 → 자동으로 차단
+- 커밋하기 직전 → 자동으로 린트 검사
+
+내가 "해줘"라고 말할 필요가 없습니다. 조건만 맞으면 알아서 실행됩니다.
+
+### Agents = 전문가 팀
+
+**Agents는 특정 역할에 특화된 AI 분신입니다.** 각 Agent는 자신만의 컨텍스트 윈도우, 시스템 프롬프트, 도구 접근 권한을 갖습니다.
+
+예를 들어:
+- **code-reviewer**: 코드 품질, 보안, 성능 관점에서 리뷰
+- **refactor-assistant**: SOLID 원칙에 따른 리팩토링 제안
+- **reflector**: 세션 회고 및 실수 패턴 분석
+
+코드가 복잡해 보이면 리팩토링 전문가를 부르고, 코드가 완성되면 리뷰 전문가를 부르는 식으로 역할을 분담합니다.
+
+---
+
+## 실제 Plugin 구조
+
+실제로 Plugin 디렉토리가 어떻게 구성되는지 봅시다.
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json           # Plugin 매니페스트 (필수)
+├── skills/                   # 배경 지식 & 슬래시 명령어
+│   ├── python-standards/
+│   │   └── SKILL.md
+│   ├── typescript-standards/
+│   │   └── SKILL.md
+│   └── git-workflow/
+│       ├── SKILL.md
+│       └── references/       # 부가 참고 자료
+├── agents/                   # 전문가 팀
+│   ├── code-reviewer.md
+│   └── refactor-assistant.md
+├── commands/                 # 슬래시 명령어 (skills/와 병행 가능)
+│   ├── code-review.md
+│   └── reflect.md
+├── hooks/                    # 자동 규칙
+│   └── hooks.json
+├── scripts/                  # 유틸리티 스크립트
+│   └── validate.sh
+└── templates/                # 프로젝트 초기화 템플릿
+    └── project/
+```
+
+### plugin.json: 매니페스트 파일
+
+Plugin의 핵심은 `.claude-plugin/plugin.json`입니다. 이 파일이 있어야 Claude Code가 Plugin으로 인식합니다.
+
+```json title=".claude-plugin/plugin.json"
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "팀 개발 표준 및 워크플로우 자동화",
+  "author": {
+    "name": "Your Name"
+  },
+  "repository": "https://github.com/you/my-plugin",
+  "license": "MIT"
+}
+```
+
+필수 필드는 `name` 하나뿐입니다. 나머지는 선택사항이지만, 공유할 Plugin이라면 `version`과 `description`은 채워두는 게 좋습니다.
+
+---
+
+## Plugin 설치와 관리
+
+### 설치
+
+```bash
+# GitHub 저장소에서 설치
+claude plugin install github:namyoungkim/leo-claude-plugin
+
+# 로컬 개발 중인 플러그인 테스트
+claude --plugin-dir ./my-plugin
+```
+
+### 설치 범위
+
+| 범위 | 설정 파일 | 용도 |
+|------|----------|------|
+| `user` | `~/.claude/settings.json` | 모든 프로젝트에 적용 (기본) |
+| `project` | `.claude/settings.json` | 이 프로젝트만, 팀과 공유 가능 |
+| `local` | `.claude/settings.local.json` | 이 프로젝트만, gitignore 대상 |
+
+### 관리 명령어
+
+```bash
+claude plugin enable my-plugin     # 활성화
+claude plugin disable my-plugin    # 비활성화
+claude plugin update my-plugin     # 업데이트
+claude plugin uninstall my-plugin  # 제거
+```
+
+---
+
+## 환경 변수: `${CLAUDE_PLUGIN_ROOT}`
+
+Plugin 개발에서 가장 중요한 환경 변수가 하나 있습니다.
+
+**`${CLAUDE_PLUGIN_ROOT}`** 는 Plugin 디렉토리의 절대 경로를 담고 있습니다. hooks.json이나 스크립트에서 Plugin 내부 파일을 참조할 때 사용합니다.
+
+```json title="hooks/hooks.json"
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Edit|Write",
+      "hooks": [{
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh"
+      }]
+    }]
+  }
+}
+```
+
+:::warning 주의
+`${CLAUDE_PLUGIN_ROOT}`는 hooks.json이나 셸 스크립트 등 **런타임 환경**에서만 동작합니다. SKILL.md 같은 Markdown 파일에서는 변수 치환이 되지 않습니다.
+:::
+
+---
+
+## 정리: Plugin은 AI와의 계약서
+
+Plugin이 무엇인지 정리하면:
+
+| 구성 요소 | 역할 | 파일 위치 |
+|-----------|------|----------|
+| **Skills** | 배경 지식 & 슬래시 명령어 | `skills/*/SKILL.md` |
+| **Commands** | 슬래시 명령어 (Skills와 통합) | `commands/*.md` |
+| **Hooks** | 자동 실행 규칙 | `hooks/hooks.json` |
+| **Agents** | 역할별 AI 전문가 | `agents/*.md` |
+| **Templates** | 프로젝트 초기화 키트 | `templates/` |
+
+이 다섯 가지가 모여서 하나의 Plugin이 됩니다. 한 번 만들어두면 여러 프로젝트에서 재사용할 수 있고, 팀원들과 공유할 수 있습니다.
+
+---
+
+## 다음 편 예고
+
+다음 편에서는 **Skills과 Commands를 직접 만드는 방법**을 다룹니다. SKILL.md의 frontmatter 옵션, 호출 제어 방식, 그리고 실제로 만들면서 겪었던 실수들까지 이야기합니다.
+
+---
+
+**Claude Code Plugin 만들기 시리즈**
+- [1편: Plugin 입문](/blog/claude-code-plugin-part1) ← 지금 읽는 글
+- [2편: 스킬과 커맨드](/blog/claude-code-plugin-part2)
+- [3편: 훅으로 자동화](/blog/claude-code-plugin-part3)
+- [4편: 자기 개선 루프](/blog/claude-code-plugin-part4)

--- a/blog/2026-02-08-claude-code-plugin-part2.md
+++ b/blog/2026-02-08-claude-code-plugin-part2.md
@@ -1,0 +1,295 @@
+---
+slug: claude-code-plugin-part2
+title: "[Claude Code Plugin 만들기 #2] 스킬과 커맨드 — AI에게 새 능력 가르치기"
+authors: namyoungkim
+tags: [claude, claude-code, plugin, ai, dev-tools, tutorial]
+---
+
+> 이 글은 Claude Code Plugin 만들기 시리즈의 두 번째 편입니다. Skill과 Command를 직접 만드는 방법, SKILL.md frontmatter 옵션, 그리고 실수 사례를 다룹니다.
+
+---
+
+## TL;DR
+
+- Skill = SKILL.md 파일 하나로 Claude에게 배경 지식을 가르치는 것
+- Command와 Skill은 공식적으로 통합됨 — 둘 다 `/skill-name`으로 호출
+- frontmatter의 `user-invocable`, `disable-model-invocation`으로 호출 방식 제어
+- `references/` 패턴으로 긴 내용을 분리하여 컨텍스트 효율 극대화
+
+<!-- truncate -->
+
+---
+
+## Skill 만들기: AI의 참고서
+
+Skill은 Claude Code가 자동으로 참고하는 참고서입니다. 특정 상황에서 "이 규칙이 있었지"라고 Claude가 알아서 떠올리게 만듭니다.
+
+### SKILL.md 기본 구조
+
+모든 Skill은 디렉토리 안의 `SKILL.md` 파일로 정의됩니다.
+
+```
+skills/
+└── python-standards/
+    └── SKILL.md          # 필수
+```
+
+SKILL.md는 YAML frontmatter로 시작합니다.
+
+```yaml title="skills/python-standards/SKILL.md"
+---
+name: python-standards
+description: "Python 프로젝트 감지 시 uv + ruff + pytest 규칙 적용"
+user-invocable: false
+---
+
+Python 프로젝트를 다룰 때는 항상:
+- uv를 패키지 매니저로 사용합니다.
+- ruff로 코드 스타일을 검사합니다.
+- pytest를 테스트 프레임워크로 사용합니다.
+```
+
+`description`은 Claude가 "이 Skill을 언제 써야 하는지" 판단하는 기준입니다. 명확하게 작성할수록 적절한 시점에 적용됩니다.
+
+---
+
+## SKILL.md Frontmatter 완전 정복
+
+공식 문서 기준으로, 사용 가능한 frontmatter 필드를 모두 정리합니다.
+
+### 필드 목록
+
+| 필드 | 필수 | 설명 |
+|------|------|------|
+| `name` | 아니오 | 스킬 이름. 생략하면 디렉토리명 사용. 소문자, 숫자, 하이픈만 |
+| `description` | 권장 | 무엇을 하는 스킬인지, 언제 사용하는지 |
+| `user-invocable` | 아니오 | `false`면 `/` 메뉴에서 숨김. 기본값: `true` |
+| `disable-model-invocation` | 아니오 | `true`면 Claude가 자동 로딩하지 않음. 기본값: `false` |
+| `argument-hint` | 아니오 | 자동완성 시 표시되는 힌트. 예: `[issue-number]` |
+| `allowed-tools` | 아니오 | 스킬 활성 시 허용할 도구 목록 |
+| `model` | 아니오 | 스킬 활성 시 사용할 모델 |
+| `context` | 아니오 | `fork`으로 설정하면 서브에이전트에서 실행 |
+| `agent` | 아니오 | `context: fork` 시 사용할 에이전트 타입 |
+| `hooks` | 아니오 | 스킬 라이프사이클에 스코프된 hooks |
+
+### 호출 제어: 3가지 모드
+
+frontmatter 조합에 따라 Skill의 동작이 달라집니다.
+
+| 설정 | 사용자 호출 | Claude 자동 호출 | 용도 |
+|------|-----------|-----------------|------|
+| 기본값 (설정 없음) | O | O | 범용 스킬 |
+| `disable-model-invocation: true` | O | X | 수동 전용 워크플로우 |
+| `user-invocable: false` | X | O | 배경 지식, 자동 규칙 |
+
+#### 모드 1: 기본값 — 누구나 부를 수 있는 스킬
+
+```yaml
+---
+name: code-review
+description: "코드 변경사항에 대한 리뷰"
+---
+```
+
+사용자가 `/code-review`로 호출할 수도 있고, Claude가 상황에 맞다고 판단하면 자동으로 참고할 수도 있습니다.
+
+#### 모드 2: 수동 전용 — 명시적으로 불러야 하는 스킬
+
+```yaml
+---
+name: product-planning
+description: "인터뷰 기반 제품 기획 및 설계"
+disable-model-invocation: true
+---
+```
+
+복잡한 워크플로우처럼 "사용자가 의도적으로 시작해야 하는" 스킬에 적합합니다. Claude가 임의로 시작하지 않습니다.
+
+#### 모드 3: 배경 지식 — Claude만 참고하는 스킬
+
+```yaml
+---
+name: python-standards
+description: "Python 프로젝트 감지 시 uv + ruff + pytest 규칙 적용"
+user-invocable: false
+---
+```
+
+`/python-standards`로 호출할 수 없고, Claude가 Python 코드를 다룰 때 자동으로 참고합니다. 우리 Plugin에서는 `python-standards`, `go-standards`, `rust-standards`, `typescript-standards` 4개 언어 표준 스킬이 모두 이 모드를 씁니다.
+
+---
+
+## 변수 치환: 동적 컨텍스트
+
+SKILL.md에서 사용할 수 있는 변수들이 있습니다.
+
+### 인자 치환
+
+```yaml
+---
+name: coding-problem-solver
+description: "코딩 문제 풀이 정리"
+argument-hint: "[문제 URL 또는 이름]"
+---
+
+$ARGUMENTS를 분석하여 풀이를 정리합니다.
+```
+
+사용자가 `/coding-problem-solver https://leetcode.com/problems/two-sum`이라고 입력하면, `$ARGUMENTS`가 URL로 치환됩니다.
+
+| 변수 | 설명 |
+|------|------|
+| `$ARGUMENTS` | 전달된 모든 인자 |
+| `$0`, `$1`, ... | 인자를 인덱스로 접근 |
+| `${CLAUDE_SESSION_ID}` | 현재 세션 ID |
+
+### 동적 컨텍스트 주입: `` !`command` ``
+
+셸 명령어의 결과를 스킬 컨텍스트에 직접 주입할 수 있습니다.
+
+```yaml title="skills/git-master/SKILL.md"
+---
+name: git-master
+description: "커밋 아키텍트 + 히스토리 전문가"
+---
+
+## 현재 상태
+- 변경 파일: !`git status -s`
+- 최근 커밋: !`git log --oneline -5`
+- 현재 브랜치: !`git branch --show-current`
+```
+
+`` !`command` `` 구문은 스킬이 로딩될 때 실행되어 결과를 Claude에게 전달합니다. 이를 통해 매번 "git status 먼저 확인해줘"라고 말하지 않아도 됩니다.
+
+---
+
+## references/ 패턴: 길어지면 분리하기
+
+SKILL.md가 너무 길어지면 `references/` 디렉토리에 분리합니다.
+
+```
+skills/
+└── typescript-standards/
+    ├── SKILL.md                           # 핵심 규칙 (간결하게)
+    └── references/
+        ├── claude-snippet.md              # CLAUDE.md용 코드 조각
+        ├── conventions-snippet.md         # 컨벤션 상세
+        └── settings-snippet.json          # 설정 파일 템플릿
+```
+
+Claude는 SKILL.md를 먼저 로딩하고, 필요할 때만 references/ 파일을 읽습니다. 이렇게 하면 **컨텍스트 윈도우를 효율적으로 사용**할 수 있습니다.
+
+:::tip 컨텍스트 예산
+Skill description은 컨텍스트 윈도우의 **2% 이내**로 제한됩니다. SKILL.md 본문은 500줄 이내로 유지하고, 나머지는 references/로 분리하는 것이 좋습니다.
+:::
+
+---
+
+## 서브에이전트에서 실행하기
+
+복잡한 스킬은 독립된 컨텍스트에서 실행할 수 있습니다.
+
+```yaml
+---
+name: deep-research
+description: "주제에 대한 깊은 리서치"
+context: fork
+agent: Explore
+allowed-tools: Bash(gh *)
+---
+
+$ARGUMENTS에 대해 철저히 조사하세요.
+```
+
+`context: fork`를 설정하면 메인 대화와 분리된 서브에이전트에서 실행됩니다. 리서치가 끝나면 결과만 메인 대화에 반환합니다.
+
+---
+
+## 실수 사례 1: 네이티브 명령어 충돌
+
+### 뭐가 문제였나
+
+처음 Plugin을 만들 때 `/review`라고 커맨드 이름을 지었는데, Claude Code에 이미 같은 이름이 있었습니다.
+
+### 어떻게 고쳤나
+
+`/review` → `/code-review`로 이름을 변경했습니다. 하지만 한 파일만 바꾸면 되는 게 아니었습니다.
+
+1. 커맨드 파일: `commands/code-review.md`
+2. 에이전트 파일: `agents/code-reviewer.md`에서 커맨드 호출 부분
+3. CLAUDE.md: 스킬 목록 업데이트
+4. README.md: 사용법 업데이트
+
+:::danger 교훈
+새 커맨드를 만들기 전에 `/help`로 Claude Code 네이티브 명령어 목록을 먼저 확인하세요. 이미 존재하는 이름과 충돌하면 예상치 못한 동작이 발생합니다.
+:::
+
+---
+
+## 실수 사례 2: 경로 참조 문제
+
+### 뭐가 문제였나
+
+Plugin 스킬은 "사용자의 프로젝트 폴더"에서 실행됩니다. 그런데 Plugin 파일 자체는 다른 경로에 있습니다.
+
+```
+사용자 프로젝트:  /home/leo/my-project/
+Plugin 파일:     ~/.claude/plugins/cache/.../my-plugin/
+```
+
+SKILL.md에서 Plugin 내부 파일을 참조하려면 경로를 알아야 하는데, 하드코딩하면 안 됩니다.
+
+### 해결 방법
+
+**hooks.json이나 스크립트에서는** `${CLAUDE_PLUGIN_ROOT}` 환경 변수를 사용합니다.
+
+```json
+{
+  "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh"
+}
+```
+
+**SKILL.md에서는** 상대 경로로 references/ 파일을 참조합니다. Claude가 SKILL.md를 읽을 때, 같은 디렉토리의 파일을 자연스럽게 접근할 수 있습니다.
+
+:::warning 주의
+`${CLAUDE_PLUGIN_ROOT}`는 Markdown 파일 내에서 변수 치환이 되지 않습니다. 셸 환경(hooks.json, scripts/)에서만 동작합니다.
+:::
+
+---
+
+## Skill vs Command 정리
+
+공식 문서에서 Commands와 Skills는 통합되었습니다. 실제로 `.claude/commands/review.md`와 `.claude/skills/review/SKILL.md`는 동일하게 `/review`를 생성합니다.
+
+| 구분 | Skills | Commands (레거시) |
+|------|--------|------------------|
+| 파일 위치 | `skills/name/SKILL.md` | `commands/name.md` |
+| frontmatter | 전체 옵션 지원 | 기본 옵션 |
+| references | `references/` 패턴 지원 | 지원 안 함 |
+| 호출 방식 | 동일 (`/name`) | 동일 (`/name`) |
+
+신규 개발 시에는 `skills/` 디렉토리에 SKILL.md로 만드는 것을 권장합니다. `commands/`도 계속 동작하지만, frontmatter 옵션이나 references 패턴을 활용하려면 skills가 더 유연합니다.
+
+---
+
+## 정리
+
+- **Skill 파일**: `skills/<name>/SKILL.md` 하나면 충분
+- **호출 제어**: `user-invocable`과 `disable-model-invocation` 조합으로 3가지 모드
+- **변수 치환**: `$ARGUMENTS`, `` !`command` `` 로 동적 컨텍스트
+- **references/**: 긴 내용은 분리하여 컨텍스트 효율 극대화
+- **실수 방지**: 네이티브 명령어 충돌 확인, 경로는 `${CLAUDE_PLUGIN_ROOT}` 사용
+
+---
+
+## 다음 편 예고
+
+다음 편에서는 **Hooks로 자동화**를 다룹니다. hooks.json의 구조, 이벤트 종류, 그리고 가장 중요한 **exit code의 의미**(exit 0, exit 1, exit 2의 차이)를 실제 디버깅 사례와 함께 설명합니다.
+
+---
+
+**Claude Code Plugin 만들기 시리즈**
+- [1편: Plugin 입문](/blog/claude-code-plugin-part1)
+- [2편: 스킬과 커맨드](/blog/claude-code-plugin-part2) ← 지금 읽는 글
+- [3편: 훅으로 자동화](/blog/claude-code-plugin-part3)
+- [4편: 자기 개선 루프](/blog/claude-code-plugin-part4)

--- a/blog/2026-02-08-claude-code-plugin-part3.md
+++ b/blog/2026-02-08-claude-code-plugin-part3.md
@@ -1,0 +1,460 @@
+---
+slug: claude-code-plugin-part3
+title: "[Claude Code Plugin 만들기 #3] 훅으로 자동화 — 규칙은 한 번 정하면 자동으로"
+authors: namyoungkim
+tags: [claude, claude-code, plugin, hooks, ai, dev-tools, tutorial]
+---
+
+> 이 글은 Claude Code Plugin 만들기 시리즈의 세 번째 편입니다. Hooks의 구조, 이벤트 종류, exit code의 정확한 의미, 그리고 실전 디버깅 사례를 다룹니다.
+
+---
+
+## TL;DR
+
+- Hooks는 `hooks.json`에 정의하는 자동 실행 규칙
+- 14가지 이벤트 중 `PreToolUse`, `PostToolUse`, `SessionStart`가 핵심
+- **exit 0** = 성공, **exit 2** = 의도적 차단, **그 외** = 에러
+- `exit 1`은 "차단"이 아니라 "에러" — 이 차이를 모르면 버그를 만든다
+- hook 타입: `command`(셸 명령), `prompt`(LLM 평가), `agent`(다중 턴 검증) 3가지
+
+<!-- truncate -->
+
+---
+
+## Hook이 뭔가요?
+
+코드를 저장할 때마다 이런 말을 해야 한다고 생각해봅시다.
+
+"들여쓰기가 이상한데 정리해줘. 그리고 이 파일은 .env니까 절대 수정하지 마."
+
+매번 이런 말을 하는 건 비효율적입니다. **Hooks를 쓰면 이 모든 일을 자동으로 처리합니다.** 규칙을 한 번만 정하면, 앞으로는 조건이 맞을 때마다 자동으로 실행됩니다.
+
+---
+
+## 이벤트 전체 목록
+
+Hook이 반응할 수 있는 이벤트는 총 14가지입니다. 공식 문서 기준으로 정리합니다.
+
+| 이벤트 | 발생 시점 | 차단 가능 |
+|--------|----------|-----------|
+| `SessionStart` | 세션 시작/재개 시 | X |
+| `UserPromptSubmit` | 사용자가 프롬프트 제출 시 | O |
+| `PreToolUse` | 도구 실행 직전 | O |
+| `PermissionRequest` | 권한 대화상자 표시 시 | O |
+| `PostToolUse` | 도구 실행 성공 직후 | X |
+| `PostToolUseFailure` | 도구 실행 실패 직후 | X |
+| `Notification` | 알림 발생 시 | X |
+| `SubagentStart` | 서브에이전트 생성 시 | X |
+| `SubagentStop` | 서브에이전트 종료 시 | O |
+| `Stop` | Claude 응답 완료 시 | O |
+| `TeammateIdle` | 팀 멤버 대기 상태 시 | O |
+| `TaskCompleted` | 작업 완료 표시 시 | O |
+| `PreCompact` | 컨텍스트 압축 직전 | X |
+| `SessionEnd` | 세션 종료 시 | X |
+
+실무에서 가장 많이 쓰는 건 `PreToolUse`, `PostToolUse`, `SessionStart` 세 가지입니다.
+
+---
+
+## hooks.json 구조
+
+hooks.json은 3단계 중첩으로 구성됩니다.
+
+```
+이벤트 → matcher 그룹 → hook 핸들러
+```
+
+```json title="hooks/hooks.json"
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Bash 실행 전 검사'",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### matcher: 언제 실행할지 필터링
+
+`matcher`는 정규표현식입니다. 이벤트별로 필터링 대상이 다릅니다.
+
+| 이벤트 | matcher 대상 | 예시 |
+|--------|-------------|------|
+| `PreToolUse`, `PostToolUse` | 도구 이름 | `Bash`, `Edit\|Write`, `mcp__.*` |
+| `SessionStart` | 시작 방식 | `startup`, `resume`, `clear` |
+| `SessionEnd` | 종료 사유 | `clear`, `logout` |
+| `SubagentStart` | 에이전트 타입 | `Explore`, `Plan` |
+| `Stop`, `UserPromptSubmit` | 지원 안 함 | 항상 실행 |
+
+`"*"`, `""`, 또는 matcher 자체를 생략하면 모든 경우에 실행됩니다.
+
+### Hook 핸들러 필드
+
+| 필드 | 필수 | 설명 |
+|------|------|------|
+| `type` | O | `"command"`, `"prompt"`, `"agent"` |
+| `command` | type=command 시 | 실행할 셸 명령어 |
+| `prompt` | type=prompt/agent 시 | LLM에 보낼 프롬프트 |
+| `timeout` | X | 제한 시간 (초). command 기본값: 600초 |
+| `statusMessage` | X | 실행 중 표시할 스피너 메시지 |
+| `async` | X | `true`면 백그라운드 실행 (command만 지원) |
+| `once` | X | `true`면 세션당 1회만 실행 (skills 전용) |
+
+---
+
+## Hook의 3가지 타입
+
+### 1. command: 셸 명령 실행
+
+가장 기본적인 타입입니다. 셸 명령어를 실행하고, exit code로 결과를 전달합니다.
+
+```json
+{
+  "type": "command",
+  "command": "bash -c 'ruff format \"$CLAUDE_FILE_PATH\"'",
+  "timeout": 10
+}
+```
+
+### 2. prompt: LLM 단일 턴 평가
+
+Claude 모델(기본: Haiku)에게 판단을 맡깁니다. 모델은 `{"ok": true/false, "reason": "..."}` 형태로 응답합니다.
+
+```json
+{
+  "type": "prompt",
+  "prompt": "이 Bash 명령어가 안전한지 평가하세요: $ARGUMENTS"
+}
+```
+
+### 3. agent: 다중 턴 서브에이전트
+
+Read, Grep, Glob 도구를 사용하는 서브에이전트를 띄웁니다. 최대 50턴까지 실행됩니다. 복잡한 검증 로직에 적합합니다.
+
+```json
+{
+  "type": "agent",
+  "prompt": "이 코드 변경이 기존 테스트를 깨뜨리지 않는지 검증하세요"
+}
+```
+
+---
+
+## Exit Code: 가장 중요한 개념
+
+**이 섹션이 이 글의 핵심입니다.** Hook의 exit code는 세 가지 의미를 가지며, 이를 정확히 이해하지 못하면 미묘한 버그를 만듭니다.
+
+### exit 0 — 성공 (정상 완료)
+
+Hook이 정상적으로 실행되었다는 뜻입니다. stdout에 JSON을 출력하면 Claude Code가 파싱합니다.
+
+```bash title="SessionStart hook 예시"
+# git 정보를 출력하여 Claude에게 컨텍스트 전달
+echo "Branch: $(git branch --show-current)"
+echo "Recent:"
+git log --oneline -3
+exit 0
+```
+
+`SessionStart`와 `UserPromptSubmit` 이벤트에서는 stdout이 Claude의 컨텍스트에 추가됩니다. 나머지 이벤트에서는 verbose 모드(`Ctrl+O`)에서만 보입니다.
+
+### exit 2 — 의도적 차단 (블로킹)
+
+**"이 동작을 막겠다"는 의도적 신호입니다.** stderr 내용이 Claude에게 에러 메시지로 전달됩니다.
+
+```bash title="main 브랜치 커밋 차단 예시"
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" = "main" ]; then
+  echo '{"decision":"block","reason":"main 브랜치 직접 커밋 금지"}' >&2
+  exit 2
+fi
+```
+
+차단 가능한 이벤트와 동작:
+
+| 이벤트 | exit 2 효과 |
+|--------|------------|
+| `PreToolUse` | 도구 실행 차단 |
+| `PermissionRequest` | 권한 거부 |
+| `UserPromptSubmit` | 프롬프트 처리 차단 |
+| `Stop` | Claude 종료 방지, 대화 계속 |
+| `PostToolUse` | 차단 불가 (이미 실행됨), stderr만 Claude에게 표시 |
+
+### exit 1 (또는 기타 non-zero) — 의도치 않은 에러
+
+**exit 0도 아니고 exit 2도 아닌 모든 exit code는 "에러"로 취급됩니다.** stderr이 verbose 모드에서만 표시되고, 실행은 계속됩니다.
+
+이것이 왜 중요할까요? 실제로 우리가 겪었던 버그를 봅시다.
+
+---
+
+## 실수 사례: `command -v` 실패와 exit 1의 함정
+
+### 문제 상황
+
+처음에 자동 포맷팅 hook을 이렇게 작성했습니다.
+
+```bash
+# "ruff가 있으면 포맷팅, 없으면 건너뛰기"라는 의도
+command -v ruff >/dev/null 2>&1 && ruff format "$CLAUDE_FILE_PATH"
+```
+
+이 코드의 의도는 명확합니다: ruff가 설치되어 있으면 포맷팅하고, 없으면 조용히 넘어가라.
+
+### 뭐가 문제였나
+
+ruff가 설치되지 않은 환경에서 이 명령어를 실행하면:
+
+```
+command -v ruff    → 실패 (ruff 없음)
+                   → && 뒤의 ruff format은 실행되지 않음
+                   → 스크립트의 마지막 exit code = command -v의 exit code = 1
+```
+
+**exit 1은 "에러"입니다.** Claude Code는 이것을 "hook이 에러로 실패했다"고 판단합니다.
+
+의도는 "도구가 없으니 건너뛰기"였지만, 실제로는 "에러 발생"으로 처리된 것입니다.
+
+### 핵심: exit code 정리
+
+```
+exit 0  → 정상 (포맷터 실행 완료, 또는 정보 출력)
+exit 2  → 의도적 차단 (보호 규칙 발동)
+exit 1  → 의도치 않은 에러 (이번에 수정한 버그)
+```
+
+**exit 2만 "의도적 차단"이고, 그 외 non-zero는 전부 에러 취급**이라는 점이 핵심입니다.
+
+### 해결 방법
+
+```bash
+# 수정 후: 도구가 없으면 정상 종료(exit 0)로 건너뛰기
+if command -v ruff >/dev/null 2>&1; then
+  ruff format "$CLAUDE_FILE_PATH"
+fi
+# if 블록 전체가 끝나면 exit 0
+```
+
+이렇게 하면:
+- ruff가 **있으면** → 포맷팅 실행, 성공 시 exit 0
+- ruff가 **없으면** → if 조건 불일치, 자연스럽게 exit 0
+- ruff가 **있는데 포맷팅 실패하면** → exit 1 (진짜 에러), Claude에게 알림
+
+---
+
+## `|| true` 패턴의 위험성
+
+비슷한 맥락에서, `|| true` 패턴도 주의가 필요합니다.
+
+```bash
+# 위험: 모든 에러를 삼켜버림
+ruff format "$CLAUDE_FILE_PATH" || true
+```
+
+이 패턴은 "ruff가 없어도 OK, ruff가 있는데 실패해도 OK"가 됩니다. 진짜 에러까지 무시해버리는 것입니다.
+
+올바른 패턴과 비교해봅시다:
+
+| 패턴 | 도구 없음 | 도구 있고 성공 | 도구 있고 실패 |
+|------|----------|-------------|-------------|
+| `command -v X && X file` | exit 1 (에러!) | exit 0 | exit 1 (에러) |
+| `X file \|\| true` | exit 0 (삼킴!) | exit 0 | exit 0 (삼킴!) |
+| `if command -v X; then X file; fi` | exit 0 (정상) | exit 0 | exit 1 (에러) |
+
+**세 번째 패턴이 정답입니다.** 도구가 없는 건 정상적으로 건너뛰고, 도구가 있는데 실패하면 에러를 보여줍니다.
+
+---
+
+## 실전 예시 4가지
+
+우리 Plugin에서 실제로 사용하는 hook들을 공식 문서 기반으로 정리합니다.
+
+### 1. SessionStart: 세션 시작 시 컨텍스트 주입
+
+```json
+{
+  "matcher": "startup",
+  "hooks": [{
+    "type": "command",
+    "command": "bash -c 'if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then echo \"Branch: $(git branch --show-current)\"; echo \"Recent:\"; git log --oneline -3; fi; exit 0'",
+    "timeout": 5
+  }]
+}
+```
+
+세션이 시작되면 현재 브랜치와 최근 커밋 이력을 Claude에게 자동으로 알려줍니다. `SessionStart`에서 stdout은 Claude의 컨텍스트에 추가되므로, Claude가 프로젝트 상태를 바로 파악할 수 있습니다.
+
+:::info matcher 값
+`SessionStart`의 matcher는 세션 시작 방식을 필터링합니다: `startup`(처음 시작), `resume`(재개), `clear`(초기화), `compact`(압축 후).
+:::
+
+### 2. PostToolUse: 파일 저장 후 자동 포맷팅
+
+```json
+{
+  "matcher": "Edit|Write",
+  "hooks": [{
+    "type": "command",
+    "command": "bash -c 'if [[ \"$CLAUDE_FILE_PATH\" == *.py ]]; then if command -v ruff >/dev/null 2>&1; then ruff format \"$CLAUDE_FILE_PATH\"; fi; fi'",
+    "timeout": 10
+  }]
+}
+```
+
+파일이 수정(`Edit`) 또는 생성(`Write`)될 때마다, 파일 확장자를 확인하고 해당 언어의 포맷터를 자동 실행합니다.
+
+우리 Plugin에서는 4개 언어를 각각 처리합니다:
+- `.py` → `ruff format`
+- `.rs` → `rustfmt`
+- `.go` → `gofmt -w`
+- `.ts/.tsx/.js/.jsx` → `prettier --write`
+
+### 3. PreToolUse: 민감한 파일 보호
+
+```json
+{
+  "matcher": "Edit|Write",
+  "hooks": [{
+    "type": "command",
+    "command": "bash -c 'echo \"$CLAUDE_FILE_PATH\" | grep -qiE \"(\\.env($|\\.)|\\.pem$|\\.key$|secrets/)\" && echo \"{\\\"decision\\\": \\\"block\\\", \\\"reason\\\": \\\"민감 파일 수정 차단\\\"}\" && exit 2 || true'"
+  }]
+}
+```
+
+`.env`, `.pem`, `.key`, `secrets/` 등 민감한 파일을 수정하려고 하면 `exit 2`로 차단합니다. 이때 `decision: "block"`과 `reason`을 JSON으로 전달하면, Claude가 차단 사유를 이해하고 대안을 제시합니다.
+
+### 4. PreToolUse: 위험한 명령어 차단
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [{
+    "type": "command",
+    "command": "bash -c 'CMD=\"$CLAUDE_BASH_COMMAND\"; echo \"$CMD\" | grep -qE \"(rm\\s+-rf\\s+/|sudo\\s|chmod\\s+777)\" && echo \"{\\\"decision\\\": \\\"block\\\", \\\"reason\\\": \\\"위험 명령 차단: $CMD\\\"}\" && exit 2 || true'"
+  }]
+}
+```
+
+`rm -rf /`, `sudo`, `chmod 777` 같은 위험한 명령어를 Bash로 실행하려고 하면 차단합니다.
+
+---
+
+## PreToolUse의 고급 기능: permissionDecision
+
+PreToolUse hook에서는 단순 차단 외에도 세밀한 제어가 가능합니다.
+
+```json
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow",
+    "permissionDecisionReason": "안전한 읽기 전용 명령어",
+    "updatedInput": { "command": "ls -la" },
+    "additionalContext": "이 명령어는 안전합니다"
+  }
+}
+```
+
+| 필드 | 설명 |
+|------|------|
+| `permissionDecision` | `allow`(허용), `deny`(거부), `ask`(사용자에게 물어보기) |
+| `permissionDecisionReason` | 결정 사유 |
+| `updatedInput` | 도구 입력을 수정 (명령어 변환 등) |
+| `additionalContext` | Claude에게 추가 컨텍스트 전달 |
+
+---
+
+## 환경 변수
+
+Hook 실행 시 사용할 수 있는 환경 변수들입니다.
+
+| 변수 | 설명 |
+|------|------|
+| `$CLAUDE_PROJECT_DIR` | 프로젝트 루트 경로 |
+| `${CLAUDE_PLUGIN_ROOT}` | Plugin 디렉토리 경로 |
+| `$CLAUDE_FILE_PATH` | 현재 대상 파일 경로 (Edit/Write 시) |
+| `$CLAUDE_BASH_COMMAND` | 실행하려는 Bash 명령어 (Bash 도구 시) |
+| `$CLAUDE_ENV_FILE` | 환경 변수 영속화 파일 (SessionStart 전용) |
+
+---
+
+## timeout 설정 주의
+
+timeout의 단위는 **초(seconds)** 입니다.
+
+```json
+{
+  "timeout": 10
+}
+```
+
+| 작업 | 권장 timeout |
+|------|-------------|
+| 포맷팅 | 10초 |
+| 린트 검사 | 30초 |
+| 빌드 검증 | 60초 |
+
+:::danger 실수 사례
+`timeout: 5000`이라고 쓰면 5000초 = **83분**입니다. 밀리초가 아닙니다! 이 실수로 hook이 1시간 넘게 대기한 적이 있습니다.
+:::
+
+---
+
+## Hook 정의 위치
+
+Hook은 여러 곳에서 정의할 수 있고, 모두 병합되어 실행됩니다.
+
+| 위치 | 범위 | 공유 가능 |
+|------|------|-----------|
+| `~/.claude/settings.json` | 모든 프로젝트 | X (로컬 전용) |
+| `.claude/settings.json` | 현재 프로젝트 | O (커밋 가능) |
+| `.claude/settings.local.json` | 현재 프로젝트 | X (gitignore) |
+| Plugin `hooks/hooks.json` | Plugin 활성 시 | O (Plugin에 포함) |
+| Skill/Agent frontmatter | 컴포넌트 활성 시 | O (파일에 정의) |
+
+---
+
+## 디버깅
+
+Hook이 예상대로 동작하지 않을 때:
+
+```bash
+# 디버그 모드로 Claude Code 실행
+claude --debug
+```
+
+또는 실행 중에 `Ctrl+O`로 verbose 모드를 토글하면 hook 실행 로그를 볼 수 있습니다.
+
+---
+
+## 정리: exit code 한눈에 보기
+
+| Exit Code | 의미 | 동작 |
+|-----------|------|------|
+| **0** | 성공 | stdout을 파싱, 정상 진행 |
+| **2** | 의도적 차단 | stderr을 Claude에게 전달, 동작 차단 |
+| **1 (기타)** | 에러 | stderr을 verbose에서만 표시, 진행 계속 |
+
+**핵심: exit 2만 의도적 차단이고, 그 외 non-zero는 전부 에러 취급입니다.**
+
+---
+
+## 다음 편 예고
+
+마지막 4편에서는 **자기 개선 루프**를 다룹니다. `/reflect`로 실수를 기록하고, `/harvest`로 여러 프로젝트의 지식을 수집하고, `/prune`으로 핵심만 남기는 사이클. 마치 오답노트를 정리하듯, AI도 계속 성장할 수 있습니다.
+
+---
+
+**Claude Code Plugin 만들기 시리즈**
+- [1편: Plugin 입문](/blog/claude-code-plugin-part1)
+- [2편: 스킬과 커맨드](/blog/claude-code-plugin-part2)
+- [3편: 훅으로 자동화](/blog/claude-code-plugin-part3) ← 지금 읽는 글
+- [4편: 자기 개선 루프](/blog/claude-code-plugin-part4)

--- a/blog/2026-02-08-claude-code-plugin-part4.md
+++ b/blog/2026-02-08-claude-code-plugin-part4.md
@@ -1,0 +1,306 @@
+---
+slug: claude-code-plugin-part4
+title: "[Claude Code Plugin 만들기 #4] 자기 개선 루프 — AI가 스스로 성장하게 만들기"
+authors: namyoungkim
+tags: [claude, claude-code, plugin, ai, dev-tools, tutorial]
+---
+
+> 이 글은 Claude Code Plugin 만들기 시리즈의 마지막 편입니다. Plugin이 시간이 지남에 따라 계속 발전하는 자기 개선 시스템을 구축하는 방법을 다룹니다.
+
+---
+
+## TL;DR
+
+- Plugin은 한 번 만들고 끝이 아니라, 계속 발전시키는 것
+- `/reflect` → `/harvest` → `/prune` 3단계 사이클로 지식 축적
+- `docs/MISTAKES.md`와 `docs/PATTERNS.md`에 교훈을 체계적으로 기록
+- scope 태그(`universal` vs `project-only`)로 지식의 재사용 범위를 결정
+- 일관성 검증 스크립트로 설정 간 불일치 자동 감지
+
+<!-- truncate -->
+
+---
+
+## Plugin이 끝이 아니라 시작이다
+
+Plugin을 만들었으면 끝일까요? 아닙니다. 진짜 강력한 건 **AI가 경험에서 배우고 계속 성장하는 시스템**을 만드는 것입니다.
+
+시험만 보고 끝내면 다음 시험도 같은 실수를 반복합니다. 하지만 틀린 문제를 오답노트에 정리하고, 반복되는 패턴을 분석하면? 계속 성장하게 됩니다.
+
+**AI도 마찬가지입니다.** 한 번 설정해놓은 Plugin은 시간이 지나면서 버그, 패턴, 실수가 쌓입니다. 이걸 자동으로 정리하고 학습하게 만드는 게 자기 개선 루프입니다.
+
+---
+
+## 자기 개선 삼총사: Reflect → Harvest → Prune
+
+세 가지 커맨드가 AI를 성장시킵니다.
+
+### 1단계: /reflect — 오답노트 쓰기
+
+매 세션이 끝나면 `/reflect`를 실행합니다.
+
+```
+Claude Code> /reflect
+```
+
+AI가 이번 세션에서 한 일, 실수, 배운 점을 분석합니다. 결과는 두 파일에 기록됩니다:
+
+- **`docs/MISTAKES.md`** — 실수와 교훈
+- **`docs/PATTERNS.md`** — 유용한 코드 패턴
+
+예를 들어 이번 세션에서 "timeout 단위를 착각했다"면:
+
+```markdown title="docs/MISTAKES.md"
+### [2026-02-08] Hook timeout 단위 착각
+- **scope**: universal
+- **프로젝트**: leo-claude-plugin
+- **상황**: hooks.json에서 timeout을 5000으로 설정
+- **원인**: 밀리초로 착각했지만 실제 단위는 초
+- **교훈**: ALWAYS hook timeout은 초 단위. 밀리초가 아님. 10초 = timeout: 10
+- **관련 파일**: hooks/hooks.json
+```
+
+여기서 **scope 태그**가 중요합니다:
+- `universal` — 모든 프로젝트에서 유용한 교훈
+- `project-only` — 이 프로젝트에서만 해당하는 교훈
+
+### 2단계: /harvest — 여러 프로젝트의 지식 수집
+
+여러 프로젝트를 진행하다 보면 각 프로젝트의 `docs/MISTAKES.md`에 교훈이 쌓입니다.
+
+```
+Claude Code> /harvest
+```
+
+`/harvest`를 실행하면 `universal`로 태그된 항목들을 모아옵니다. 그리고 물어봅니다:
+
+- "이걸 새로운 Skill로 추가할까요?"
+- "CLAUDE.md에 규칙으로 넣을까요?"
+- "Hook으로 자동화할까요?"
+
+예를 들어, 여러 프로젝트에서 "timeout 단위 착각" 실수가 반복되면:
+1. Skill에 timeout 가이드를 추가하거나
+2. Hook에 timeout 값 검증 로직을 넣거나
+3. CLAUDE.md에 "timeout은 초 단위" 규칙을 명시
+
+**중요: 사람의 승인 후에만 반영합니다.** AI가 자동으로 설정을 바꾸면 위험하기 때문입니다.
+
+### 3단계: /prune — 핵심만 남기고 정리
+
+시간이 지나면 CLAUDE.md가 길어집니다. 규칙, 패턴, 주의사항이 계속 쌓이기 때문입니다.
+
+```
+Claude Code> /prune
+```
+
+CLAUDE.md를 **50줄 이내**로 유지하는 것이 목표입니다. 어떻게?
+
+1. **긴 내용** → `docs/` 폴더로 이동
+2. **자동화 가능한 검증** → Hook으로 전환
+3. **중복되거나 불필요한 것** → 삭제
+
+:::tip 비유
+필기노트가 10페이지가 되면 핵심만 요약해서 1페이지 요약본을 만드는 것과 같습니다. CLAUDE.md는 요약본이고, docs/는 원본 노트입니다.
+:::
+
+---
+
+## 문서 체계: 4개의 핵심 파일
+
+자기 개선 시스템은 4개의 문서 파일로 구성됩니다.
+
+```
+docs/
+├── MISTAKES.md              # 실수와 교훈 기록
+├── PATTERNS.md              # 자주 쓰는 코드 패턴
+├── ARCHITECTURE.md          # 아키텍처 결정 기록 (ADR)
+└── CONVENTIONS.md           # 코딩 컨벤션
+```
+
+### MISTAKES.md — 실수 기록
+
+```markdown
+### [YYYY-MM-DD] 제목
+- **scope**: universal | project-only
+- **프로젝트**: {프로젝트명}
+- **상황**: 무엇을 하다가 문제가 발생했는가
+- **원인**: 근본 원인은 무엇이었는가
+- **교훈**: ALWAYS/NEVER 형태로 작성
+- **관련 파일**: 해당 파일 경로
+```
+
+`ALWAYS/NEVER` 형태로 교훈을 작성하면 Claude가 명확하게 규칙을 인식합니다.
+
+- "ALWAYS hook timeout은 초 단위로 작성할 것"
+- "NEVER `|| true`로 모든 에러를 삼키지 말 것"
+
+### PATTERNS.md — 패턴 기록
+
+```markdown
+## 패턴 이름
+- **scope**: universal | project-only
+- **발견일**: YYYY-MM-DD
+- **용도**: 언제 사용하는가
+- **코드 예시**: (코드 블록)
+- **주의사항**: 사용 시 유의할 점
+```
+
+반복적으로 사용하는 좋은 패턴을 기록합니다. 예를 들어 "도구 존재 여부 체크 후 실행" 패턴:
+
+```bash
+# 도구가 없으면 건너뛰고, 있으면 실행하는 표준 패턴
+if command -v ruff >/dev/null 2>&1; then
+  ruff format "$FILE"
+fi
+```
+
+---
+
+## 일관성 검증: validate.sh
+
+자기 개선만큼 중요한 게 **일관성 유지**입니다. 하나를 바꿨는데 관련된 곳을 안 바꾸면 불일치가 생깁니다.
+
+### 실수 사례: 버전 불일치
+
+```json title="plugin.json"
+{ "version": "2.0.0" }
+```
+
+```json title="marketplace.json"
+{ "version": "1.5.0" }
+```
+
+"왜 업데이트가 안 되지?" 라고 헤매다가 버전이 달랐던 것을 발견. 이런 실수를 자동으로 잡기 위해 `validate.sh`를 만들었습니다.
+
+### validate.sh가 검증하는 것들
+
+```bash
+./scripts/validate.sh
+```
+
+- plugin.json과 marketplace.json의 버전 일치 여부
+- README.md에 기재된 스킬/커맨드 목록이 실제 파일과 일치하는지
+- hooks.json의 timeout 값이 합리적인 범위인지
+- 모든 스킬 파일에 필수 frontmatter가 있는지
+
+**"하나 바꾸면 관련된 곳 전부 확인해야 합니다. 자동 검증 스크립트가 있으면 훨씬 편합니다."**
+
+---
+
+## 전체 프로젝트 리뷰: 부분만 보면 다 괜찮은데...
+
+플러그인을 처음부터 끝까지 리뷰하면서 발견한 교훈들을 단계별로 정리합니다.
+
+### Skills 리뷰
+
+4개 언어(Python, TypeScript, Go, Rust) 표준 스킬의 구조가 제각각이었습니다.
+
+**문제**: python-standards는 상세한데 go-standards는 간략하고, 각각 다른 형식을 씀
+**해결**: 모든 언어 스킬의 구조를 통일
+
+```
+skills/<lang>-standards/
+├── SKILL.md                    # 핵심 규칙 (동일 형식)
+└── references/
+    ├── claude-snippet.md       # CLAUDE.md용 조각
+    ├── conventions-snippet.md  # 컨벤션 상세
+    └── settings-snippet.json   # 설정 템플릿
+```
+
+### Commands 리뷰
+
+**문제**: `/review` 커맨드 이름이 네이티브 명령어와 충돌
+**해결**: `/code-review`로 변경 (2편에서 상세히 다룸)
+
+### Hooks 리뷰
+
+**문제**: `|| true` 패턴으로 진짜 에러까지 무시
+**해결**: `if command -v; then ...; fi` 패턴으로 교체 (3편에서 상세히 다룸)
+
+### 통합 리뷰
+
+**문제**: 버전 불일치, README와 실제 파일 불일치, 경로 오류
+**해결**: validate.sh로 자동 검증
+
+:::warning 핵심 교훈
+부분만 보면 괜찮아 보이는데, 전체를 보면 안 맞는 게 보입니다. 정기적인 전체 리뷰가 필요합니다.
+:::
+
+---
+
+## CLAUDE.md에 자기 개선 규칙 넣기
+
+AI가 자기 개선 루프를 자동으로 실행하게 만들려면, CLAUDE.md에 이런 규칙을 추가합니다:
+
+```markdown title="CLAUDE.md"
+## 자기 개선
+
+- 세션 종료 전 `/reflect` 실행을 제안할 것
+- 반복되는 실수 발견 시 CLAUDE.md 업데이트를 제안할 것
+- 3회 이상 같은 파일 수정 시 설계 재검토를 제안할 것
+```
+
+이 세 줄이 전부입니다. 하지만 강력합니다.
+
+AI가:
+- 매 세션 마지막에 "지금 `/reflect` 실행해볼까요?"라고 제안
+- 같은 실수를 반복하면 "이거 패턴인데, 규칙으로 만들까요?"라고 알림
+- 같은 파일을 계속 수정하면 "설계부터 다시 봐야 할 것 같은데요?"라고 제안
+
+---
+
+## 자기 개선 사이클 전체 흐름
+
+```
+일상 개발
+  │
+  ├─ 세션 종료 → /reflect
+  │    └─ MISTAKES.md, PATTERNS.md 업데이트
+  │
+  ├─ 주기적으로 → /harvest
+  │    └─ universal 항목 수집 → 새 Skill, Hook, 규칙 제안
+  │
+  └─ CLAUDE.md 비대화 → /prune
+       └─ 긴 내용 → docs/ 이동, 자동화 가능 → Hook 전환
+```
+
+이 사이클을 반복하면 Plugin은 점점 똑똑해집니다:
+
+1. **1주차**: 기본 규칙만 있는 Plugin
+2. **1개월 후**: 실수 10건 기록, 패턴 5개 발견
+3. **3개월 후**: 반복 실수는 Hook으로 자동 방지, 핵심 패턴은 Skill로 정착
+
+---
+
+## 시리즈 마무리
+
+4편에 걸쳐 Claude Code Plugin의 전체를 다뤘습니다.
+
+| 편 | 제목 | 핵심 |
+|---|------|------|
+| 1편 | Plugin 입문 | Plugin 개념, 구조, 설치 |
+| 2편 | 스킬과 커맨드 | SKILL.md 작성법, frontmatter, 호출 제어 |
+| 3편 | 훅으로 자동화 | hooks.json, exit code, 실전 예시 |
+| 4편 | 자기 개선 루프 | reflect/harvest/prune 사이클 |
+
+### 핵심 메시지
+
+**Plugin은 한 번 만들고 끝이 아니라, AI와 함께 계속 발전시키는 시스템입니다.**
+
+처음에는 버그도 많고 규칙도 부족합니다. 하지만 `/reflect` → `/harvest` → `/prune` 사이클을 반복하면 점점 좋아집니다. 마치:
+
+- 처음 배운 악기는 삑삑거립니다
+- 연습하고, 실수를 기록하고, 반복하면
+- 어느새 음악이 됩니다
+
+AI도 그렇고, Plugin도 그렇습니다.
+
+---
+
+**Claude Code Plugin 만들기 시리즈**
+- [1편: Plugin 입문](/blog/claude-code-plugin-part1)
+- [2편: 스킬과 커맨드](/blog/claude-code-plugin-part2)
+- [3편: 훅으로 자동화](/blog/claude-code-plugin-part3)
+- [4편: 자기 개선 루프](/blog/claude-code-plugin-part4) ← 지금 읽는 글
+
+GitHub: [github.com/namyoungkim/leo-claude-plugin](https://github.com/namyoungkim/leo-claude-plugin)

--- a/static/blog-tags.json
+++ b/static/blog-tags.json
@@ -189,5 +189,38 @@
     "best-practices",
     "clean-code",
     "philosophy"
+  ],
+  "/blog/claude-code-plugin-part1": [
+    "claude",
+    "claude-code",
+    "plugin",
+    "ai",
+    "dev-tools",
+    "tutorial"
+  ],
+  "/blog/claude-code-plugin-part2": [
+    "claude",
+    "claude-code",
+    "plugin",
+    "ai",
+    "dev-tools",
+    "tutorial"
+  ],
+  "/blog/claude-code-plugin-part3": [
+    "claude",
+    "claude-code",
+    "plugin",
+    "hooks",
+    "ai",
+    "dev-tools",
+    "tutorial"
+  ],
+  "/blog/claude-code-plugin-part4": [
+    "claude",
+    "claude-code",
+    "plugin",
+    "ai",
+    "dev-tools",
+    "tutorial"
   ]
 }

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -5,9 +5,18 @@
 ## 📚 Documentation
 
 - /docs/: 👋 문서에 오신 것을 환영합니다
+- /docs/AGENT_TEAM_TEMPLATES: Agent Team 구성 템플릿
+- /docs/ARCHITECTURE: 아키텍처 결정 기록 (ADR)
+- /docs/CONVENTIONS: 코딩 컨벤션
+- /docs/MISTAKES: 실수와 교훈 기록
+- /docs/PATTERNS: 자주 쓰는 패턴
 
 ## ✍️ Blog Posts
 
+- /blog/claude-code-plugin-part4: [Claude Code Plugin 만들기 #4] 자기 개선 루프 — AI가 스스로 성장하게 만들기
+- /blog/claude-code-plugin-part3: [Claude Code Plugin 만들기 #3] 훅으로 자동화 — 규칙은 한 번 정하면 자동으로
+- /blog/claude-code-plugin-part2: [Claude Code Plugin 만들기 #2] 스킬과 커맨드 — AI에게 새 능력 가르치기
+- /blog/claude-code-plugin-part1: [Claude Code Plugin 만들기 #1] Plugin 입문 — AI 비서에게 업무 매뉴얼 만들어주기
 - /blog/go-code-philosophy: Go 코드 철학: 좋은 Go 코드란 무엇인가?
 - /blog/go-project-setup-guide: Go 프로젝트 세팅 완벽 가이드: 초보자도 5분이면 끝!
 - /blog/claude-code-plugins-guide: Claude Code 플러그인 완전 정복 — 설치부터 사내 마켓플레이스 구축까지


### PR DESCRIPTION
## Summary
- Claude Code Plugin 만들기 시리즈 4편 블로그 포스트 추가
  - 1편: Plugin 입문 (구조, 설치, 환경 변수)
  - 2편: 스킬과 커맨드 (SKILL.md, frontmatter, 호출 제어)
  - 3편: 훅으로 자동화 (hooks.json, exit code 0/1/2 상세 설명)
  - 4편: 자기 개선 루프 (reflect/harvest/prune 사이클)
- 공식 문서(code.claude.com) 기반으로 정확한 기술 내용 작성
- inbox/ 초안을 정제하여 블로그 형식으로 재구성

## Test plan
- [x] `npm run build` 빌드 성공 확인
- [ ] 로컬에서 포스트 렌더링 확인 (`npm start`)
- [ ] 시리즈 내부 링크 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)