### PR TITLE
docs: add session reflection results

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -29,4 +29,18 @@
 
 ## 기록
 
-_(아직 기록이 없습니다. `/reflect` 실행 후 자동으로 추가됩니다.)_
+### [2026-02-08] rm -rf 절대 경로 Hook 오탐
+- **scope**: universal
+- **프로젝트**: a1rtisan-dev-blog
+- **상황**: `rm -rf /Users/leo/project/a1rtisan-dev-blog/inbox/` 실행 시 Hook이 차단
+- **원인**: deny 패턴이 절대 경로 `/Users/...`를 `rm -rf /` 패턴으로 오탐
+- **교훈**: ALWAYS 상대 경로로 rm 명령 실행 (예: `rm -r inbox/`). NEVER 절대 경로로 rm -rf 실행
+- **관련 파일**: ~/.claude/settings.json (permissions.deny)
+
+### [2026-02-08] /init-project 실행 후 main 브랜치 직접 커밋
+- **scope**: universal
+- **프로젝트**: a1rtisan-dev-blog
+- **상황**: /init-project로 파일 생성 후 main 브랜치에 직접 커밋 3개 생성
+- **원인**: 프로젝트 초기화 작업이라 브랜치 생성을 간과
+- **교훈**: ALWAYS 작업 시작 전 브랜치 확인. NEVER main/master에 직접 커밋. 실수 시 `git reset --soft` + 브랜치 이동으로 복구
+- **관련 파일**: .claude/settings.json (hooks.PreToolUse)

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -29,4 +29,46 @@
 
 ## 패턴 목록
 
-_(아직 패턴이 없습니다. `/reflect` 실행 후 자동으로 추가됩니다.)_
+### git reset --soft로 커밋 재구성
+- **scope**: universal
+- **발견일**: 2026-02-08
+- **프로젝트**: a1rtisan-dev-blog
+- **용도**: main 브랜치에 직접 커밋한 것을 feature 브랜치로 옮길 때
+- **코드 예시**:
+  ```bash
+  git branch feature/my-work          # 현재 커밋을 브랜치로 보존
+  git reset --soft origin/main        # main을 원래 상태로 되돌림 (변경사항 유지)
+  git restore --staged .              # 스테이징 해제
+  git checkout -- .                   # 변경사항 폐기 (브랜치에 이미 보존됨)
+  git checkout feature/my-work        # 브랜치로 이동
+  ```
+- **주의사항**: `--hard` 대신 `--soft` 사용. 이미 push한 커밋은 이 방법 사용 불가
+
+### 블로그 시리즈 구조화
+- **scope**: project-only
+- **발견일**: 2026-02-08
+- **프로젝트**: a1rtisan-dev-blog
+- **용도**: 연관된 여러 포스트를 시리즈로 작성할 때
+- **코드 예시**:
+  ```
+  파일명: YYYY-MM-DD-topic-partN.md
+  태그: 공통 태그 + 시리즈 태그
+  하단: 시리즈 전체 링크 목록
+  각 파트: 독립적으로 읽을 수 있도록 구성
+  ```
+- **주의사항**: 각 파트의 TL;DR 필수. 시리즈 내부 링크는 slug 기반 절대 경로 사용
+
+### inbox/ 초안 검증 프로세스
+- **scope**: universal
+- **발견일**: 2026-02-08
+- **프로젝트**: a1rtisan-dev-blog
+- **용도**: 빠르게 작성한 초안을 공식 문서 기반으로 정확하게 재작성할 때
+- **코드 예시**:
+  ```
+  1. inbox/에 빠른 초안 작성 (추측, 메모 포함 가능)
+  2. 공식 문서/소스 코드로 기술적 정확성 검증
+  3. blog/에 정제된 포스트 작성
+  4. npm run build로 빌드 확인
+  5. inbox/ 삭제
+  ```
+- **주의사항**: inbox/는 untracked 상태 유지. 추측성 내용은 반드시 검증 후 포함


### PR DESCRIPTION
## Summary
- `/reflect` 세션 회고 결과 반영
- `docs/MISTAKES.md`: rm -rf 오탐, main 직접 커밋 실수 2건 추가
- `docs/PATTERNS.md`: soft reset 재구성, 시리즈 구조화, inbox 프로세스 패턴 3건 추가

## Test plan
- [x] 문서 형식이 MISTAKES.md/PATTERNS.md 작성 규칙에 맞는지 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)